### PR TITLE
Some fixes to the context_2d_clearRect and context_2d_resize functions

### DIFF
--- a/tealeaf_canvas.c
+++ b/tealeaf_canvas.c
@@ -130,6 +130,20 @@ bool tealeaf_canvas_context_2d_bind(context_2d *ctx) {
 }
 
 /**
+ * @name  teleaf_canvas_context_2d_rebind
+ * @brief if the given context is active, rebind it
+ * @param ctx - (context_2d *) context to rebind
+ * @retval  NONE
+ */
+void tealeaf_canvas_context_2d_rebind(context_2d *ctx)
+{
+    if (canvas.active_ctx == ctx) {
+        canvas.active_ctx = NULL;
+        tealeaf_canvas_context_2d_bind(ctx);
+    }
+}
+
+/**
  * @name	tealeaf_canvas_resize
  * @brief	resize's the onscreen canvas
  * @param	w - (int) width to resize to

--- a/tealeaf_canvas.h
+++ b/tealeaf_canvas.h
@@ -41,6 +41,7 @@ void tealeaf_canvas_bind_render_buffer(context_2d_p ctx);
 void tealeaf_canvas_bind_texture_buffer(context_2d_p ctx);
 void tealeaf_canvas_resize(int w, int h);
 bool tealeaf_canvas_context_2d_bind(context_2d_p ctx);
+void tealeaf_canvas_context_2d_rebind(context_2d_p ctx);
 
 tealeaf_canvas *tealeaf_canvas_get();
 void tealeaf_canvas_init(int framebuffer_name);

--- a/tealeaf_context.c
+++ b/tealeaf_context.c
@@ -215,7 +215,7 @@ unsigned char *context_2d_read_pixels(context_2d *ctx) {
     draw_textures_flush();
     unsigned char *buffer = NULL;
     buffer = (unsigned char *)malloc(sizeof(unsigned char) * 4 * ctx->width * ctx->height);
-    glReadPixels(0, 0, ctx->width, ctx->height, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
+    GLTRACE(glReadPixels(0, 0, ctx->width, ctx->height, GL_RGBA, GL_UNSIGNED_BYTE, buffer));
     return buffer;
 }
 
@@ -643,8 +643,8 @@ void context_2d_restore(context_2d *ctx) {
 void context_2d_clear(context_2d *ctx) {
     draw_textures_flush();
     context_2d_bind(ctx);
-    glClearColor(0, 0, 0, 0);
-    glClear(GL_COLOR_BUFFER_BIT);
+    GLTRACE(glClearColor(0, 0, 0, 0));
+    GLTRACE(glClear(GL_COLOR_BUFFER_BIT));
 }
 
 /**

--- a/tealeaf_context.c
+++ b/tealeaf_context.c
@@ -776,24 +776,8 @@ void context_2d_scale(context_2d *ctx, float x, float y) {
  * @retval	NONE
  */
 void context_2d_clearRect(context_2d *ctx, const rect_2d *rect) {
-    draw_textures_flush();
-    context_2d_bind(ctx);
-    tealeaf_shaders_bind(PRIMARY_SHADER);
-
-    // Draw a rectangle using triangle strip:
-    //    (0,1)-(2,3)-(4,5) and (2,3)-(4,5)-(6,7)
-    //
-    // With coordinates:
-    //    4,5  -  6,7
-    //     |   \   |
-    //    0,1  -  2,3
-    GLfloat v[8];
-    matrix_3x3_multiply(GET_MODEL_VIEW_MATRIX(ctx), rect, (float *)&v[4], (float *)&v[5], (float *)&v[6], (float *)&v[7], (float *)&v[2], (float *)&v[3], (float *)&v[0], (float *)&v[1]);
-    GLTRACE(glBlendFunc(GL_ONE, GL_ZERO));
-    GLTRACE(glUniform4f(global_shaders[PRIMARY_SHADER].draw_color, 0, 0, 0, 0)); // set color to 0
-    GLTRACE(glVertexAttribPointer(global_shaders[PRIMARY_SHADER].vertex_coords, 2, GL_FLOAT, GL_FALSE, 0, v));
-    GLTRACE(glDrawArrays(GL_TRIANGLE_STRIP, 0, 4));
-    GLTRACE(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
+    rgba color = { 0, 0, 0, 0 };
+    context_2d_fillRect(ctx, rect, &color);
 }
 
 /**

--- a/tealeaf_context.c
+++ b/tealeaf_context.c
@@ -290,6 +290,8 @@ void context_2d_resize(context_2d *ctx, int width, int height) {
         ctx->backing_height = tex->height;
         ctx->width = tex->originalWidth;
         ctx->height = tex->originalHeight;
+
+        tealeaf_canvas_context_2d_rebind(ctx);
     }
 }
 


### PR DESCRIPTION
Resize needs to bind its newly created texture if the context is bound and clearRect now simply wraps to fillRect with the color black.