### PR TITLE
Critical memory reset

### DIFF
--- a/texture_manager.c
+++ b/texture_manager.c
@@ -899,8 +899,9 @@ void texture_manager_memory_critical() {
     m_memory_critical = true;
 }
 
-void texture_manager_memory_reset() {
-    LOGFN("texture_manager_memory_reset");
+void texture_manager_reset_memory_critical() {
+    LOGFN("texture_manager_reset_memory_critical");
+
     m_memory_critical = false;
 }
 

--- a/texture_manager.c
+++ b/texture_manager.c
@@ -899,6 +899,11 @@ void texture_manager_memory_critical() {
     m_memory_critical = true;
 }
 
+void texture_manager_memory_reset() {
+    LOGFN("texture_manager_memory_reset");
+    m_memory_critical = false;
+}
+
 /*
  * For devices with known low memory limits, we can start with a lower memory limit
  * to avoid depending on low memory warnings.  This fixes issues where we cannot

--- a/texture_manager.h
+++ b/texture_manager.h
@@ -75,6 +75,7 @@ bool texture_manager_on_texture_loaded(texture_manager *manager,
 void texture_manager_on_texture_failed_to_load(texture_manager *manager, const char *url);
 void texture_manager_memory_warning();
 void texture_manager_memory_critical();
+void texture_manager_memory_reset();
 void texture_manager_set_max_memory(texture_manager *manager, long bytes); // Will only ratchet down
 void image_cache_load_callback(struct image_data *data);
 texture_manager *texture_manager_acquire();

--- a/texture_manager.h
+++ b/texture_manager.h
@@ -75,7 +75,7 @@ bool texture_manager_on_texture_loaded(texture_manager *manager,
 void texture_manager_on_texture_failed_to_load(texture_manager *manager, const char *url);
 void texture_manager_memory_warning();
 void texture_manager_memory_critical();
-void texture_manager_memory_reset();
+void texture_manager_reset_memory_critical();
 void texture_manager_set_max_memory(texture_manager *manager, long bytes); // Will only ratchet down
 void image_cache_load_callback(struct image_data *data);
 texture_manager *texture_manager_acquire();


### PR DESCRIPTION
Function to reset critical memory warning flag.

This function is needed for https://github.com/gameclosure/native-android/pull/39