### PR TITLE
Update timestep_animate.cpp

### DIFF
--- a/timestep/timestep_animate.cpp
+++ b/timestep/timestep_animate.cpp
@@ -149,6 +149,7 @@ void view_animation_clear(view_animation *anim) {
 
     view_animation_unschedule(anim);
     anim->elapsed = 0;
+    anim->is_paused = false;
     def_animate_remove_from_group(anim->js_anim);
     LOGFN("end view_animation_clear");
 }


### PR DESCRIPTION
If you try to call animate(...).clear() on paused animation, next call animate(...).pause() won't work. This happens because clear() doesn't reset paused state for the object.

See: https://github.com/gameclosure/timestep/pull/114